### PR TITLE
カラーマネジメント関連のブラッシュアップおよび不具合修正

### DIFF
--- a/application.c
+++ b/application.c
@@ -4660,6 +4660,13 @@ void ExecuteChangeCanvasIccProfile(GtkWidget* menu, APPLICATION* app)
 		cmsCloseProfile(monitor_profile);
 	}
 
+	// （ディスプレイフィルタを切り替えて）表示を更新
+	{
+		GtkCheckMenuItem *item = GTK_CHECK_MENU_ITEM(app->menus.display_filter_menus[DISPLAY_FUNC_TYPE_ICC_PROFILE]);
+		gtk_check_menu_item_set_active(item, FALSE);
+		gtk_check_menu_item_set_active(item, TRUE);
+	}
+
 	g_free(before_path);
 }
 

--- a/application.h
+++ b/application.h
@@ -475,6 +475,14 @@ typedef struct _APPLICATION
 * init_file_name	: 初期化ファイルの名前                           *
 *********************************************************************/
 EXTERN void InitializeApplication(APPLICATION* app, char* init_file_name);
+ 
+/*********************************************************************
+* UpdateWindowTitle関数                                              *
+* ウインドウタイトルの更新                                           *
+* 引数                                                               *
+* app				: アプリケーション全体を管理する構造体のアドレス *
+*********************************************************************/
+EXTERN void UpdateWindowTitle(APPLICATION* app);
 
 /*********************************************************
 * GetActiveDrawWindow関数                                *

--- a/application.h
+++ b/application.h
@@ -1049,25 +1049,28 @@ EXTERN void ChangeNavigationDrawWindow(NAVIGATION_WINDOW* navigation, DRAW_WINDO
 * NoDisplayFilter関数                                *
 * 表示時のフィルターをオフ                           *
 * 引数                                               *
+* menu	: メニューウィジェット                       *
 * app	: アプリケーションを管理する構造体のアドレス *
 *****************************************************/
-EXTERN void NoDisplayFilter(APPLICATION* app);
+EXTERN void NoDisplayFilter(GtkWidget* menu, APPLICATION* app);
 
 /*****************************************************
 * GrayScaleDisplayFilter関数                         *
 * 表示時のフィルターをグレースケール変換のものへ     *
 * 引数                                               *
+* menu	: メニューウィジェット                       *
 * app	: アプリケーションを管理する構造体のアドレス *
 *****************************************************/
-EXTERN void GrayScaleDisplayFilter(APPLICATION* app);
+EXTERN void GrayScaleDisplayFilter(GtkWidget* menu, APPLICATION* app);
 
 /******************************************************************
 * GrayScaleDisplayFilterYIQ関数                                   *
 * 表示時のフィルターをグレースケール変換(YIQカラーモデル)のものへ *
 * 引数                                                            *
+* menu	: メニューウィジェット                                    *
 * app	: アプリケーションを管理する構造体のアドレス              *
 ******************************************************************/
-EXTERN void GrayScaleDisplayFilterYIQ(APPLICATION* app);
+EXTERN void GrayScaleDisplayFilterYIQ(GtkWidget* menu, APPLICATION* app);
 
 /*****************************************************
 * IccProfileDisplayFilter関数                        *

--- a/clip_board.c
+++ b/clip_board.c
@@ -101,11 +101,11 @@ static void ClipBoardImageRecieveCallBack(
 		gtk_widget_set_sensitive(app->layer_window.layer_control.mode, TRUE);
 		gtk_widget_set_sensitive(app->layer_window.layer_control.lock_opacity, TRUE);
 
-		// ウィンドウのタイトルを画像名に
-		gtk_window_set_title(GTK_WINDOW(app->window), app->labels->menu.clip_board);
-
 		// 描画領域のカウンタを更新
 		app->window_num++;
+
+		// ウィンドウのタイトルを画像名に
+		UpdateWindowTitle(app);
 	}
 	else
 	{	// 描画領域に新たにレイヤーを作成してコピー

--- a/color.c
+++ b/color.c
@@ -2110,6 +2110,46 @@ cmsHPROFILE* GetPrimaryMonitorProfile(void)
 
 	if (profile)
 		return profile;
+#elif defined GDK_WINDOWING_X11
+	cmsHPROFILE *profile = NULL;
+	GdkScreen *screen;
+	GdkAtom type = GDK_NONE;
+	gint format = 0;
+	gint nitems = 0;
+	gint monitor = 0;
+	gchar *atom_name = NULL;
+	guchar *data = NULL;
+
+	//screen = gtk_widget_get_screen(app->window);
+	//monitor = gdk_screen_get_monitor_at_window(screen, app->window->window);
+	screen = gdk_screen_get_default();
+	monitor = 0;
+
+	if (monitor > 0)
+	{
+		atom_name = g_strdup_printf("_ICC_PROFILE_%d", monitor);
+	}
+	else
+	{
+		atom_name = g_strdup("_ICC_PROFILE");
+	}
+
+	if (gdk_property_get(gdk_screen_get_root_window (screen),
+		gdk_atom_intern(atom_name, FALSE),
+		GDK_NONE,
+		0, 64 * 1024 * 1024, FALSE,
+		&type, &format, &nitems, &data) && nitems > 0)
+	{
+	  profile = cmsOpenProfileFromMem(data, nitems);
+	  g_free(data);
+	}
+
+	g_free(atom_name);
+
+	if(profile)
+	{
+		return profile;
+	}
 #endif
 	return cmsOpenProfileFromMem(sRGB_profile, sizeof(sRGB_profile));
 }

--- a/display_filter.c
+++ b/display_filter.c
@@ -92,13 +92,15 @@ void RGBA2GrayScaleFilterYIQ(uint8* source, uint8* destination, int num_pixel, v
 * 引数                                               *
 * app	: アプリケーションを管理する構造体のアドレス *
 *****************************************************/
-void NoDisplayFilter(APPLICATION* app)
+void NoDisplayFilter(GtkWidget* menu, APPLICATION* app)
 {
-	if((app->flags & APPLICATION_IN_SWITCH_DRAW_WINDOW) == 0 && app->window_num > 0)
+	if((app->flags & APPLICATION_IN_SWITCH_DRAW_WINDOW) == 0 && app->draw_window[app->active_window] &&
+		gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(menu)) != FALSE)
 	{
 		app->draw_window[app->active_window]->display_filter_mode
 			= DISPLAY_FUNC_TYPE_NO_CONVERT;
 		app->display_filter.filter_func = NULL;
+
 		app->tool_window.color_chooser->filter_func = NULL;
 		gtk_widget_queue_draw(app->tool_window.color_chooser->widget);
 		UpdateColorBox(app->tool_window.color_chooser);
@@ -106,11 +108,7 @@ void NoDisplayFilter(APPLICATION* app)
 
 		app->draw_window[app->active_window]->flags |= DRAW_WINDOW_UPDATE_ACTIVE_OVER;
 		app->flags &= ~(APPLICATION_DISPLAY_GRAY_SCALE | APPLICATION_DISPLAY_SOFT_PROOF);
-
-		if(app->window_num > 0)
-		{
-			gtk_widget_queue_draw(app->draw_window[app->active_window]->window);
-		}
+		gtk_widget_queue_draw(app->draw_window[app->active_window]->window);
 	}
 }
 
@@ -120,13 +118,15 @@ void NoDisplayFilter(APPLICATION* app)
 * 引数                                               *
 * app	: アプリケーションを管理する構造体のアドレス *
 *****************************************************/
-void GrayScaleDisplayFilter(APPLICATION* app)
+void GrayScaleDisplayFilter(GtkWidget* menu, APPLICATION* app)
 {
-	if((app->flags & APPLICATION_IN_SWITCH_DRAW_WINDOW) == 0 && app->window_num > 0)
+	if((app->flags & APPLICATION_IN_SWITCH_DRAW_WINDOW) == 0 && app->draw_window[app->active_window] &&
+		gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(menu)) != FALSE)
 	{
 		app->draw_window[app->active_window]->display_filter_mode
 			= DISPLAY_FUNC_TYPE_GRAY_SCALE;
 		app->display_filter.filter_func = RGBA2GrayScaleFilter;
+
 		app->tool_window.color_chooser->filter_func = RGBA2GrayScaleFilter;
 		gtk_widget_queue_draw(app->tool_window.color_chooser->widget);
 		UpdateColorBox(app->tool_window.color_chooser);
@@ -135,11 +135,7 @@ void GrayScaleDisplayFilter(APPLICATION* app)
 		app->draw_window[app->active_window]->flags |= DRAW_WINDOW_UPDATE_ACTIVE_OVER;
 		app->flags |= APPLICATION_DISPLAY_GRAY_SCALE;
 		app->flags &= ~(APPLICATION_DISPLAY_SOFT_PROOF);
-
-		if(app->window_num > 0)
-		{
-			gtk_widget_queue_draw(app->draw_window[app->active_window]->window);
-		}
+		gtk_widget_queue_draw(app->draw_window[app->active_window]->window);
 	}
 }
 
@@ -149,13 +145,15 @@ void GrayScaleDisplayFilter(APPLICATION* app)
 * 引数                                                            *
 * app	: アプリケーションを管理する構造体のアドレス              *
 ******************************************************************/
-void GrayScaleDisplayFilterYIQ(APPLICATION* app)
+void GrayScaleDisplayFilterYIQ(GtkWidget* menu, APPLICATION* app)
 {
-	if((app->flags & APPLICATION_IN_SWITCH_DRAW_WINDOW) == 0 && app->window_num > 0)
+	if((app->flags & APPLICATION_IN_SWITCH_DRAW_WINDOW) == 0 && app->draw_window[app->active_window] &&
+		gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(menu)) != FALSE)
 	{
 		app->draw_window[app->active_window]->display_filter_mode
 			= DISPLAY_FUNC_TYPE_GRAY_SCALE_YIQ;
 		app->display_filter.filter_func = RGBA2GrayScaleFilterYIQ;
+
 		app->tool_window.color_chooser->filter_func = RGBA2GrayScaleFilterYIQ;
 		gtk_widget_queue_draw(app->tool_window.color_chooser->widget);
 		UpdateColorBox(app->tool_window.color_chooser);
@@ -164,11 +162,7 @@ void GrayScaleDisplayFilterYIQ(APPLICATION* app)
 		app->draw_window[app->active_window]->flags |= DRAW_WINDOW_UPDATE_ACTIVE_OVER;
 		app->flags |= APPLICATION_DISPLAY_GRAY_SCALE;
 		app->flags &= ~(APPLICATION_DISPLAY_SOFT_PROOF);
-
-		if(app->window_num > 0)
-		{
-			gtk_widget_queue_draw(app->draw_window[app->active_window]->window);
-		}
+		gtk_widget_queue_draw(app->draw_window[app->active_window]->window);
 	}
 }
 
@@ -196,33 +190,24 @@ void AdaptIccProfileDisplayFilter(uint8* source, uint8* destination, int num_pix
 *****************************************************/
 void IccProfileDisplayFilter(GtkWidget* menu, APPLICATION* app)
 {
-	if((app->flags & APPLICATION_IN_SWITCH_DRAW_WINDOW) == 0 && app->window_num > 0)
+	if((app->flags & APPLICATION_IN_SWITCH_DRAW_WINDOW) == 0 && app->draw_window[app->active_window] &&
+		gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(menu)) != FALSE)
 	{
 		app->draw_window[app->active_window]->display_filter_mode
 			= DISPLAY_FUNC_TYPE_ICC_PROFILE;
-		if(gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(menu)) != FALSE)
-		{
-			app->display_filter.filter_func = AdaptIccProfileDisplayFilter;
-			app->display_filter.filter_data = (void*)app;
-			app->tool_window.color_chooser->filter_func = AdaptIccProfileDisplayFilter;
-			app->tool_window.color_chooser->filter_data = (void*)app;
-			gtk_widget_queue_draw(app->tool_window.color_chooser->widget);
-			UpdateColorBox(app->tool_window.color_chooser);
-			gtk_widget_queue_draw(app->tool_window.color_chooser->pallete_widget);
-		}
-		else
-		{
-			app->display_filter.filter_func = NULL;
-		}
+		app->display_filter.filter_func = AdaptIccProfileDisplayFilter;
+		app->display_filter.filter_data = (void*)app;
+
+		app->tool_window.color_chooser->filter_func = AdaptIccProfileDisplayFilter;
+		app->tool_window.color_chooser->filter_data = (void*)app;
+		gtk_widget_queue_draw(app->tool_window.color_chooser->widget);
+		UpdateColorBox(app->tool_window.color_chooser);
+		gtk_widget_queue_draw(app->tool_window.color_chooser->pallete_widget);
 
 		app->draw_window[app->active_window]->flags |= DRAW_WINDOW_UPDATE_ACTIVE_OVER;
-		app->flags &= ~(APPLICATION_DISPLAY_GRAY_SCALE);
 		app->flags |= APPLICATION_DISPLAY_SOFT_PROOF;
-
-		if(app->window_num > 0)
-		{
-			gtk_widget_queue_draw(app->draw_window[app->active_window]->window);
-		}
+		app->flags &= ~(APPLICATION_DISPLAY_GRAY_SCALE);
+		gtk_widget_queue_draw(app->draw_window[app->active_window]->window);
 	}
 }
 

--- a/draw_window.c
+++ b/draw_window.c
@@ -2104,20 +2104,12 @@ void DrawWindowSetIccProfile(DRAW_WINDOW* window, int32 data_size, gboolean ask_
 				monitor_profile, TYPE_BGRA_8, INTENT_RELATIVE_COLORIMETRIC, cmsFLAGS_BLACKPOINTCOMPENSATION);
 		}
 
-		window->display_filter_mode = DISPLAY_FUNC_TYPE_ICC_PROFILE;
-		app->display_filter.filter_func = app->tool_window.color_chooser->filter_func =
-			g_display_filter_funcs[DISPLAY_FUNC_TYPE_ICC_PROFILE];
-		app->display_filter.filter_data = app->tool_window.color_chooser->filter_data = (void*)app;
-
-		gtk_widget_queue_draw(app->tool_window.color_chooser->widget);
-		UpdateColorBox(app->tool_window.color_chooser);
-		gtk_widget_queue_draw(app->tool_window.color_chooser->pallete_widget);
-
-		gtk_check_menu_item_set_active(
-			GTK_CHECK_MENU_ITEM(app->menus.display_filter_menus[DISPLAY_FUNC_TYPE_ICC_PROFILE]),
-			TRUE
-		);
-		app->flags |= APPLICATION_DISPLAY_SOFT_PROOF;
+		// （ディスプレイフィルタを切り替えて）表示を更新
+		{
+			GtkCheckMenuItem *item = GTK_CHECK_MENU_ITEM(app->menus.display_filter_menus[DISPLAY_FUNC_TYPE_ICC_PROFILE]);
+			gtk_check_menu_item_set_active(item, FALSE);
+			gtk_check_menu_item_set_active(item, TRUE);
+		}
 
 		cmsCloseProfile(monitor_profile);
 	}

--- a/draw_window.c
+++ b/draw_window.c
@@ -2071,7 +2071,7 @@ void DrawWindowSetIccProfile(DRAW_WINDOW* window, int32 data_size, gboolean ask_
 
 		gtk_widget_show_all(dialog);
 
-		result = gtk_dialog_run(GTK_DIALOG(dialog)) != GTK_RESPONSE_YES;
+		result = gtk_dialog_run(GTK_DIALOG(dialog));
 
 		gtk_widget_destroy(dialog);
 

--- a/draw_window.c
+++ b/draw_window.c
@@ -266,6 +266,15 @@ gboolean OnCloseDrawWindow(void* data, gint page)
 	// 描画領域の数を更新
 	window->app->window_num--;
 
+	// 描画領域がゼロになった場合にメニューを無効化
+	if(!window->app->window_num)
+	{
+		for(i = 0; i < window->app->menus.num_disable_if_no_open; i++)
+		{
+			gtk_widget_set_sensitive(window->app->menus.disable_if_no_open[i], FALSE);
+		}
+	}
+
 	// 描画領域の削除実行
 	DeleteDrawWindow(&window);
 

--- a/draw_window.h
+++ b/draw_window.h
@@ -323,6 +323,17 @@ EXTERN gboolean OnCloseDrawWindow(void* data, gint page);
 ***********************************************************/
 EXTERN int GetWindowID(DRAW_WINDOW* window, struct _APPLICATION* app);
 
+/*********************************************************
+* GetWindowTitle関数                                     *
+* 描画領域の情報に基づくウインドウタイトルを取得する     *
+* 引数                                                   *
+* window	: 描画領域の情報                             *
+* app		: アプリケーションを管理する構造体のアドレス *
+* 返り値                                                 *
+*	ウインドウタイトル                                   *
+*********************************************************/
+EXTERN gchar *GetWindowTitle(DRAW_WINDOW* window, struct _APPLICATION* app);
+
 /*********************************
 * DrawWindowChangeZoom関数       *
 * 描画領域の拡大縮小率を変更する *

--- a/menu.c
+++ b/menu.c
@@ -990,7 +990,7 @@ GtkWidget* GetMainMenu(
 	app->menus.display_filter_menus[DISPLAY_FUNC_TYPE_NO_CONVERT] =
 		app->menus.disable_if_no_open[app->menus.num_disable_if_no_open] =
 		radio_top = gtk_radio_menu_item_new_with_mnemonic(NULL, buff);
-	(void)g_signal_connect_swapped(G_OBJECT(radio_top), "activate",
+	(void)g_signal_connect(G_OBJECT(radio_top), "activate",
 		G_CALLBACK(NoDisplayFilter), app);
 	gtk_menu_shell_append(GTK_MENU_SHELL(sub_menu), radio_top);
 	app->menus.num_disable_if_no_open++;
@@ -1001,7 +1001,7 @@ GtkWidget* GetMainMenu(
 		app->menus.disable_if_no_open[app->menus.num_disable_if_no_open] =
 		menu_item = gtk_radio_menu_item_new_with_mnemonic(
 		gtk_radio_menu_item_get_group(GTK_RADIO_MENU_ITEM(radio_top)), buff);
-	(void)g_signal_connect_swapped(G_OBJECT(menu_item), "activate",
+	(void)g_signal_connect(G_OBJECT(menu_item), "activate",
 		G_CALLBACK(GrayScaleDisplayFilter), app);
 	gtk_menu_shell_append(GTK_MENU_SHELL(sub_menu), menu_item);
 	app->menus.num_disable_if_no_open++;
@@ -1012,7 +1012,7 @@ GtkWidget* GetMainMenu(
 		app->menus.disable_if_no_open[app->menus.num_disable_if_no_open] =
 		menu_item = gtk_radio_menu_item_new_with_mnemonic(
 		gtk_radio_menu_item_get_group(GTK_RADIO_MENU_ITEM(radio_top)), buff);
-	(void)g_signal_connect_swapped(G_OBJECT(menu_item), "activate",
+	(void)g_signal_connect(G_OBJECT(menu_item), "activate",
 		G_CALLBACK(GrayScaleDisplayFilterYIQ), app);
 	gtk_menu_shell_append(GTK_MENU_SHELL(sub_menu), menu_item);
 	app->menus.num_disable_if_no_open++;

--- a/menu.c
+++ b/menu.c
@@ -1581,7 +1581,7 @@ static void ExecuteNew(APPLICATION* app)
 		);
 
 		// ウィンドウのタイトルバーを「新規作成」に
-		gtk_window_set_title(GTK_WINDOW(app->window), app->labels->make_new.name);
+		UpdateWindowTitle(app);
 		
 		// 無効にしていた一部のメニューを有効に
 		for(i=0; i<app->menus.num_disable_if_no_open; i++)

--- a/preference.c
+++ b/preference.c
@@ -1057,6 +1057,8 @@ void ExecuteSetPreference(APPLICATION* app)
 			{
 				app->draw_window[app->active_window]->flags |= DRAW_WINDOW_UPDATE_ACTIVE_OVER;
 				gtk_widget_queue_draw(app->draw_window[app->active_window]->window);
+
+				UpdateWindowTitle(app);
 			}
 		}
 		else
@@ -1206,6 +1208,8 @@ void ExecuteSetPreference(APPLICATION* app)
 			{
 				app->draw_window[app->active_window]->flags |= DRAW_WINDOW_UPDATE_ACTIVE_OVER;
 				gtk_widget_queue_draw(app->draw_window[app->active_window]->window);
+
+				UpdateWindowTitle(app);
 			}
 
 			break;

--- a/widgets.h
+++ b/widgets.h
@@ -71,6 +71,17 @@ typedef enum _ICC_PROFILE_USAGE
 ******************************************************************************/
 EXTERN GtkWidget* IccProfileChooser(char** icc_path, ICC_PROFILE_USAGE usage);
 
+/********************************************************
+* IccProfileChangerDialogNew関数                        *
+* ICCプロファイルを選択するダイアログウィジェットを作成 *
+* 引数                                                  *
+* parent			     : 親ウインドウ                 *
+* workspace_profile_path : 作業用プロファイルのパス     *
+* 返り値                                                *
+*	ダイアログ生成用のウィジェット                      *
+********************************************************/
+EXTERN GtkWidget* IccProfileChangerDialogNew(GtkWindow *parent, gchar *workspace_profile_path);
+
 /**************************************************************************
 * IccProfileChooserDialogNew関数                                          *
 * ICCプロファイルを選択するダイアログウィジェットを作成                   *


### PR DESCRIPTION
やまかわ aka やんま ま（@yamma_ma）です。
今回のリクエストは先日OneDriveにアップロードしたパッチに相当するコードを含んでおり、以下の点に対処するものです。
- キャンバスのICCプロファイルを読み込み・変更した際にディスプレイフィルタが切り替わらない、または表示が更新されない
- キャンバスのICCプロファイルを破棄することができない
- キャンバスにICCプロファイルが割り当てられているかどうか、割り当てられているプロファイルは何か、割り当てられていない場合にどのプロファイルが使用されているのかが分からない
- ICCプロファイルが埋め込まれた画像ファイルを開いた際、Yesをクリックしてもプロファイルが読み込まれない
- Windowsではプライマリモニタのプロファイルを取得するようになっているが、Xサーバからの取得は未実装

カラーマネジメント関連ではありませんが、以下の不具合も修正しています。
- すべてのキャンバスを閉じた際、無効になるべきメニュー項目がそのままになっている
